### PR TITLE
Add ability to input existing immutable cursors

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -12,7 +12,12 @@ function Structure (options) {
   }
 
   this.key = options.key || utils.randString();
-  this.current = Immutable.fromJS(options.data || {});
+
+  if (options.data instanceof Immutable.Seq ||
+      options.data instanceof Immutable.Map)
+    this.current = options.data;
+  else
+    this.current = Immutable.fromJS(options.data || {});
 
   if (!!options.history) {
     this.history = Immutable.List.of(this.current);

--- a/tests/structure_test.js
+++ b/tests/structure_test.js
@@ -97,6 +97,23 @@ describe('immstruct', function () {
     cursor.deref().should.equal('bar');
   });
 
+  it('should accept existing immutable structures', function () {
+    var immutableObj = Immutable.fromJS({
+      foo: 'hello'
+    });
+
+    var structure = new Structure({
+      data: immutableObj
+    });
+
+    var cursor = structure.cursor(['foo']);
+    cursor.deref().should.equal('hello');
+    cursor = cursor.update(function () {
+      return 'bar';
+    });
+    cursor.deref().should.equal('bar');
+  });
+
   describe('undo/redo', function () {
 
     it('should be able to undo default', function () {


### PR DESCRIPTION
In my project I had a use case where I've already created an immutable object, and I want to add it to immstruct later on. This code works for me, and I added a simple test case. Let me know what you guys think.
