### PR TITLE
Expose Structure

### DIFF
--- a/structure.js
+++ b/structure.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/structure');


### PR DESCRIPTION
From https://github.com/omniscientjs/immstruct/issues/10#issuecomment-67311262.

I think `var Structure = require('immstruct').Structure;` is better than `var Structure = require('immstruct/src/structure');`.
