### PR TITLE
Simplify base `changeListener`.

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -54,19 +54,12 @@ Structure.prototype.cursor = function (path) {
     // Othewise an out-of-sync change occured. We ignore `oldRoot`, and focus on
     // changes at path `path`, and sync this to `self.current`.
 
-    var inNew = hasIn(newRoot, path);
-    var inOld = hasIn(self.current, path);
-
-    if(!inNew && inOld) {
+    if(!hasIn(newRoot, path)) {
       return self.current = self.current.removeIn(path);
     }
-    if(inNew && !inOld) {
-      return self.current = self.current.setIn(path, newRoot.getIn(path));
-    }
 
-    return self.current = self.current.updateIn(path, function (data) {
-      return newRoot.getIn(path);
-    });
+    // Update an existing path or add a new path within the current map.
+    return self.current = self.current.setIn(path, newRoot.getIn(path));
   };
 
   changeListener = handleHistory(this, changeListener);


### PR DESCRIPTION
When handling resync of stale cursors with the underlying immutable structure (e.g map),
we need to handle three cases based on the given keyPath indicating a change:

1. keyPath is not in the updated map, but it exists in the current (removal)
2. keyPath is in the updated map, but it doesn't exist in the current (add)
3. keyPath is in the updated map, but it also exists in the current (update)

For the first case, we need to use `Immutable.Map.removeIn`.
While `Immutable.Map.setIn` is sufficient for the other cases.

Using methods of simplifying boolean expressions (e.g. K-maps), we can just test
keyPath is not in the updated map to handle logic flow.