### PR TITLE
Provide ability to have history capped

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ at time of cursor creation. Updating it may rewrite newer information.
 ## Usage Undo/Redo
 
 ```js
-var structure = immstruct.withHistory({ 'foo': 'bar' });
+// optionalKey and/or optionalLimit can be omitted from the call
+var optionalLimit = 10; // only keep last 10 of history, default Infinity
+var structure = immstruct.withHistory('optionalKey', optionalLimit, { 'foo': 'bar' });
 console.log(structure.cursor('foo').deref()); //=> 'bar'
 
 structure.cursor('foo').update(function () { return 'hello'; });

--- a/api.md
+++ b/api.md
@@ -19,7 +19,7 @@ of Structure instances.
 
 
 
-**Returns** `Immstruct`, 
+**Returns** `Immstruct`,
 
 
 ### `immstruct.get([key], [data])`
@@ -43,7 +43,7 @@ var structure = immstruct.get('myStruct', { foo: 'Hello' });
 
 
 
-**Returns** `Structure`, 
+**Returns** `Structure`,
 
 
 ### `immstruct.clear`
@@ -78,16 +78,21 @@ Provided by key
 
 
 
-**Returns** `Boolean`, 
+**Returns** `Boolean`,
 
 
-### `immstruct.withHistory([key], [data])`
+### `immstruct.withHistory([key], [limit], [data])`
 
 Gets or creates a new instance of `Structure` with history (undo/redo)
 activated per default. Same usage and signature as regular `Immstruct.get`.
 
 Provide optional key to be able to retrieve it from list of instances.
 If no key is provided, a random key will be generated.
+
+Provide optional limit to cap the last number of history references that
+will be kept. Once limit is reached, a new history record shifts off the
+oldest record. The default if omitted is Infinity. Setting to 0 is the
+as not having history enabled in the first place.
 
 ### Examples:
 
@@ -100,11 +105,12 @@ If no key is provided, a random key will be generated.
 | param    | type             | description                             |
 | -------- | ---------------- | --------------------------------------- |
 | `[key]`  | String           | _optional:_ - defaults to random string |
+| `[limit]`| Positive Integer | _optional:_ - defaults to Infinity      |
 | `[data]` | Object,Immutable | _optional:_ - defaults to empty data    |
 
 
 
-**Returns** `Structure`, 
+**Returns** `Structure`,
 
 
 ### `immstruct([key], [data])`
@@ -137,7 +143,7 @@ is provided, a random key will be generated.
 
 
 
-**Returns** `Structure,Function`, 
+**Returns** `Structure,Function`,
 
 
 ### `Structure([options])`
@@ -177,12 +183,12 @@ Creates a new `Structure` instance. Also accessible through
 | --------- | ---------------- | ------------------------------- |
 | `history` | Immutable.List   | `Immutable.List` with history.  |
 | `current` | Object,Immutable | Provided data as immutable data |
-| `key`     | String           | Generated or provided key. 
+| `key`     | String           | Generated or provided key.
     |
 
 
 
-**Returns** `Structure`, 
+**Returns** `Structure`,
 
 
 ### `structure.cursor([path])`
@@ -253,7 +259,7 @@ See more examples in the [readme](https://github.com/omniscientjs/immstruct)
 
 
 
-**Returns** `Reference`, 
+**Returns** `Reference`,
 
 
 ### `reference.observe([eventName], callback)`
@@ -324,7 +330,7 @@ Remove all observers from reference.
 
 
 
-**Returns** `Void`, 
+**Returns** `Void`,
 
 
 ### `reference.destroy`
@@ -334,7 +340,7 @@ For cleaning up memory.
 
 
 
-**Returns** `Void`, 
+**Returns** `Void`,
 
 
 ### `structure.forceHasSwapped(newData, oldData, keyPath)`
@@ -353,7 +359,7 @@ If newData is `null` current will be used.
 
 
 
-**Returns** `Void`, 
+**Returns** `Void`,
 
 
 ### `structure.undo(steps)`
@@ -413,6 +419,4 @@ Returns the same immutable structure as passed as argument.
 
 **Returns** `Object`, New Immutable structure after undo
 
-## Private members 
-
-
+## Private members

--- a/index.js
+++ b/index.js
@@ -95,23 +95,33 @@ Immstruct.prototype.remove = function (key) {
  * Provide optional key to be able to retrieve it from list of instances.
  * If no key is provided, a random key will be generated.
  *
+ * Provide optional limit to cap the last number of history references
+ * that will be kept. Once limit is reached, a new history record
+ * shifts off the oldest record. The default if omitted is Infinity.
+ * Setting to 0 is the as not having history enabled in the first place.
+ *
  * ### Examples:
  *
  *     var immstruct = require('immstruct');
+ *     var structure = immstruct.withHistory('myStruct', 10, { foo: 'Hello' });
+ *     var structure = immstruct.withHistory(10, { foo: 'Hello' });
  *     var structure = immstruct.withHistory('myStruct', { foo: 'Hello' });
+ *     var structure = immstruct.withHistory({ foo: 'Hello' });
  *
  * @param {String} [key] - defaults to random string
+ * @param {Number} [limit] - defaults to Infinity
  * @param {Object|Immutable} [data] - defaults to empty data
  *
  * @module immstruct.withHistory
  * @api public
  * @returns {Structure}
  */
-Immstruct.prototype.withHistory = function (key, data) {
+Immstruct.prototype.withHistory = function (key, limit, data) {
   return getInstance(this, {
     key: key,
     data: data,
-    history: true
+    history: true,
+    historyLimit: limit
   });
 };
 
@@ -153,11 +163,12 @@ module.exports = function (key, data) {
   });
 };
 
-module.exports.withHistory = function (key, data) {
+module.exports.withHistory = function (key, limit, data) {
   return getInstance(inst, {
     key: key,
     data: data,
-    history: true
+    history: true,
+    historyLimit: limit
   });
 };
 
@@ -176,6 +187,13 @@ function getInstance (obj, options) {
   if (typeof options.key === 'object') {
     options.data = options.key;
     options.key = void 0;
+  } else if (typeof options.key === 'number') {
+    options.data = options.historyLimit;
+    options.historyLimit = options.key;
+    options.key = void 0;
+  } else if (typeof options.historyLimit === 'object') {
+    options.data = options.historyLimit;
+    options.historyLimit = void 0;
   }
 
   if (options.key && obj.instances[options.key]) {

--- a/src/structure.js
+++ b/src/structure.js
@@ -23,7 +23,8 @@ var utils = require('./utils');
  * {
  *   key: String, // Defaults to random string
  *   data: Object|Immutable, // defaults to empty Map
- *   history: Boolean // Defaults to false
+ *   history: Boolean, // Defaults to false
+ *   historyLimit: Number, // If history enabled, Defaults to Infinity
  * }
  * ```
  *
@@ -57,6 +58,9 @@ function Structure (options) {
   if (!!options.history) {
     this.history = Immutable.List.of(this.current);
     this._currentRevision = 0;
+    this._historyLimit = (typeof options.historyLimit === 'number') ?
+      options.historyLimit :
+      Infinity;
   }
 
   this._pathListeners = [];
@@ -383,6 +387,11 @@ function handleHistory (emitter, fn) {
     emitter.history = emitter.history
       .take(++emitter._currentRevision)
       .push(emitter.current);
+
+    if (emitter.history.size > emitter._historyLimit) {
+      emitter.history = emitter.history.takeLast(emitter._historyLimit);
+      emitter._currentRevision -= (emitter.history.size - emitter._historyLimit);
+    }
 
     return newStructure;
   };

--- a/tests/immstruct_test.js
+++ b/tests/immstruct_test.js
@@ -54,6 +54,36 @@ describe('immstruct', function () {
     structure.history.get(0).toJS().should.eql({ foo: 'bar' });
   });
 
+  it('should be able to create structure with history and key', function () {
+    var structure = immstruct.withHistory('histAndKey', { foo: 'bar' });
+    structure.current.toJS().should.be.an('object');
+    structure.history.get(0).toJS().should.eql({ foo: 'bar' });
+    var structureRef = immstruct('histAndKey');
+    structureRef.history.get(0).toJS().should.eql({ foo: 'bar' });
+  });
+
+  it('should be able to create structure with capped history', function () {
+    var limit = 1; // only keep this many history refs
+    var structure = immstruct.withHistory(limit, { foo: 'bar' });
+    structure.current.toJS().should.be.an('object');
+    structure.history.get(0).toJS().should.eql({ foo: 'bar' });
+    structure.cursor('foo').update(function () { return 'cat'; });
+    structure.history.size.should.eql(1);
+    structure.history.get(0).toJS().should.eql({ foo: 'cat' });
+  });
+
+  it('should be able to create structure with capped history and key', function () {
+    var limit = 1; // only keep this many history refs
+    var structure = immstruct.withHistory('histLimitKey', limit, { foo: 'bar' });
+    structure.current.toJS().should.be.an('object');
+    structure.history.get(0).toJS().should.eql({ foo: 'bar' });
+    structure.cursor('foo').update(function () { return 'cat'; });
+    structure.history.size.should.eql(1);
+    structure.history.get(0).toJS().should.eql({ foo: 'cat' });
+    var structureRef = immstruct('histLimitKey');
+    structureRef.history.get(0).toJS().should.eql({ foo: 'cat' });
+  });
+
   it('should give structure with random key when js object given as only argument', function () {
     var structure = immstruct({ foo: 'hello' });
     structure.current.toJS().should.have.property('foo');

--- a/tests/structure_test.js
+++ b/tests/structure_test.js
@@ -631,6 +631,85 @@ describe('structure', function () {
       structure.cursor('foo').deref().should.equal('Change 1');
     });
 
+
+    describe('with limit', function () {
+
+      it('should be able to undo default', function () {
+        var structure = new Structure({
+          data: { 'foo': 'bar' },
+          history: true,
+          historyLimit: 2
+        });
+
+        structure.cursor('foo').update(function () { return 'hello'; });
+        structure.cursor('foo').deref().should.equal('hello');
+        structure.undo();
+        structure.cursor('foo').deref().should.equal('bar');
+        structure.cursor('foo').update(function () { return 'hello2'; });
+        structure.cursor('foo').deref().should.equal('hello2');
+        structure.history.toJS().should.eql([
+          { 'foo': 'bar' },
+          { 'foo': 'hello2' }
+        ]);
+        structure.cursor('foo').update(function () { return 'hello3'; });
+        structure.cursor('foo').deref().should.equal('hello3');
+        structure.history.toJS().should.eql([
+          { 'foo': 'hello2' },
+          { 'foo': 'hello3' }
+        ]);
+      });
+
+      it('should be able to redo default', function () {
+        var structure = new Structure({
+          data: { 'foo': 'bar' },
+          history: true,
+          historyLimit: 2
+        });
+
+        structure.cursor('foo').update(function () { return 'hello'; });
+        structure.cursor('foo').deref().should.equal('hello');
+        structure.undo();
+        structure.cursor('foo').deref().should.equal('bar');
+        structure.redo();
+        structure.cursor('foo').deref().should.equal('hello');
+      });
+
+      it('should be able undo multiple steps up to capped start', function () {
+        var structure = new Structure({
+          data: { 'foo': 'bar' },
+          history: true,
+          historyLimit: 2
+        });
+
+        structure.cursor('foo').update(function () { return 'Change 1'; });
+        structure.cursor('foo').update(function () { return 'Change 2'; });
+        structure.cursor('foo').deref().should.equal('Change 2');
+
+        structure.undo(2);
+        structure.cursor('foo').deref().should.equal('Change 1');
+      });
+
+      it('should be able redo multiple steps', function () {
+        var structure = new Structure({
+          data: { 'foo': 'bar' },
+          history: true,
+          historyLimit: 2
+        });
+
+        structure.cursor('foo').update(function () { return 'Change 1'; });
+        structure.cursor('foo').update(function () { return 'Change 2'; });
+        structure.cursor('foo').update(function () { return 'Change 3'; });
+        structure.cursor('foo').deref().should.equal('Change 3');
+
+        structure.undo(3);
+        structure.cursor('foo').deref().should.equal('Change 2');
+
+        structure.redo(2);
+        structure.cursor('foo').deref().should.equal('Change 3');
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
Add the ability to have history capped to a certain number of operations which is good for long running systems or heavy data use.

By specifying the optional limit, the history mechanism will release old records once it hits the threshold.

The limit is optional and if omitted, then the limit is Infinity.

```javascript
// optionalKey and/or optionalLimit can be omitted from the call
var optionalLimit = 10; // only keep last 10 of history, default Infinity
var structure = immstruct.withHistory('optionalKey', optionalLimit, { 'foo': 'bar' });
var structureNoKey = immstruct.withHistory(optionalLimit, { 'foo': 'bar' });

var structureNoKeyUnlimited = immstruct.withHistory({ 'foo': 'bar' });
var structureKeyUnlimited = immstruct.withHistory('foo', { 'foo': 'bar' });
```