### PR TITLE
Fix IE8 'Expected identifier' error.

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -588,5 +588,5 @@ function inherits (c, p) {
     e[k] = Object.getOwnPropertyDescriptor(c.prototype, k)
   });
   c.prototype = Object.create(p.prototype, e)
-  c.super = p
+  c['super'] = p
 }


### PR DESCRIPTION
The error is thrown because of 'super' being a reserved word.