### PR TITLE
correctly traverse immutable collection and non-immutable collection by key

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -153,15 +153,15 @@ function emit(map, newData, oldData, path, args) {
 
   if (path.length > 0) {
     var nextPathRoot = path[0];
-    var passedNewData = newData && newData.get ? newData.get(nextPathRoot) : newData;
-    var passedOldData = oldData && oldData.get ? oldData.get(nextPathRoot) : oldData;
+    var passedNewData = newData && newData.get ? newData.get(nextPathRoot) : void 0;
+    var passedOldData = oldData && oldData.get ? oldData.get(nextPathRoot) : void 0;
     return emit(map.get(nextPathRoot), passedNewData, passedOldData, path.slice(1), args);
   }
 
   map.forEach(function(value, key) {
     if (key === LISTENER_SENTINEL) return void 0;
-    var passedNewData = (newData && newData.get) ? newData.get(key) : newData;
-    var passedOldData = (oldData && oldData.get) ? oldData.get(key) : oldData;
+    var passedNewData = (newData && newData.get) ? newData.get(key) : void 0;
+    var passedOldData = (oldData && oldData.get) ? oldData.get(key) : void 0;
     emit(value, passedNewData, passedOldData, [], args);
   });
 }

--- a/tests/structure_test.js
+++ b/tests/structure_test.js
@@ -823,12 +823,8 @@ describe('structure', function () {
 
       var ref = structure.reference(['foo', 'value']);
       ref.observe(function () {
-        if (i++ === 0) {
-          expect(ref.cursor().deref()).to.be.not.ok();
-        } else {
-          ref.cursor().deref().should.eql(10);
-          done();
-        }
+        ref.cursor().deref().should.eql(10);
+        done();
       });
 
       structure.cursor().update(function() {


### PR DESCRIPTION
when traversing a non-immutable collection by key, set it as `void 0`.