### PR TITLE
Update CI node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "node"


### PR DESCRIPTION
Node <= 0.12 is end-of-life [as of 2016-12-31](https://github.com/nodejs/LTS#lts-schedule1).

This PR replaces obsolete versions in Travis with the stable alias.