### PR TITLE
Use browser variants of requestAnimationFrame

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -589,8 +589,13 @@ function handleHistory (emitter, fn) {
   };
 }
 
-var _requestAnimationFrame = (typeof window !== 'undefined' &&
-  window.requestAnimationFrame) || utils.raf;
+var _requestAnimationFrame = (
+    typeof window !== 'undefined' && (
+      window.requestAnimationFrame.bind(window)
+      || window.webkitRequestAnimationFrame.bind(window)
+      || window.webkitRequestAnimationFrame.bind(window)
+      || window.mozRequestAnimationFrame.bind(window)
+      || window.mozRequestAnimationFrame.bind(window)) || utils.raf)
 
 // Update history if history is active
 function possiblyEmitAnimationFrameEvent (emitter, newStructure, oldData, keyPath) {


### PR DESCRIPTION
I assume that IE<= 11 doesn't recognize window.requestAnimationFrame in _some_ cases. My program haults at `_requestAnimationFrame()` and says that the Object is undefined. This change adds support for all browsers and fixes that bug.